### PR TITLE
Fixed the problem of UPDATE operations being executed in different transactions

### DIFF
--- a/src/DataAccess/AppDbContextTransactionEFCore.cs
+++ b/src/DataAccess/AppDbContextTransactionEFCore.cs
@@ -1,0 +1,31 @@
+﻿using Microsoft.EntityFrameworkCore.Storage;
+
+namespace DentallApp.DataAccess;
+
+public class AppDbContextTransactionEFCore : IAppDbContextTransaction
+{
+    private readonly IDbContextTransaction _transaction;
+
+    public AppDbContextTransactionEFCore(IDbContextTransaction transaction)
+    {
+        _transaction = transaction;
+    }
+
+    public void Commit()
+        => _transaction.Commit();
+
+    public async Task CommitAsync()
+        => await _transaction.CommitAsync();
+
+    public void Rollback()
+        => _transaction.Rollback();
+
+    public async Task RollbackAsync()
+        => await _transaction.RollbackAsync();
+
+    public void Dispose()
+        => _transaction.Dispose();
+
+    public async ValueTask DisposeAsync()
+        => await _transaction.DisposeAsync();
+}

--- a/src/DataAccess/IAppDbContextTransaction.cs
+++ b/src/DataAccess/IAppDbContextTransaction.cs
@@ -1,0 +1,9 @@
+﻿namespace DentallApp.DataAccess;
+
+public interface IAppDbContextTransaction : IDisposable, IAsyncDisposable
+{
+    void Commit();
+    Task CommitAsync();
+    void Rollback();
+    Task RollbackAsync();
+}

--- a/src/Repositories/IRepository.cs
+++ b/src/Repositories/IRepository.cs
@@ -9,4 +9,5 @@ public interface IRepository<TEntity> where TEntity : ModelBase
     void Update(TEntity entity);
     void Delete(TEntity entity);
     Task<int> SaveAsync();
+    Task<IAppDbContextTransaction> BeginTransactionAsync();
 }

--- a/src/Repositories/Repository.cs
+++ b/src/Repositories/Repository.cs
@@ -38,4 +38,7 @@ public class Repository<TEntity> : IRepository<TEntity> where TEntity : ModelBas
 
     public virtual Task<int> SaveAsync()
         => _context.SaveChangesAsync();
+
+    public virtual async Task<IAppDbContextTransaction> BeginTransactionAsync()
+        => new AppDbContextTransactionEFCore(await _context.Database.BeginTransactionAsync());
 }

--- a/src/UnitOfWork/IUnitOfWork.cs
+++ b/src/UnitOfWork/IUnitOfWork.cs
@@ -2,8 +2,9 @@
 
 public interface IUnitOfWork
 {
+    IAppDbContextTransaction BeginTransaction();
+    Task<IAppDbContextTransaction> BeginTransactionAsync();
     Task<int> SaveChangesAsync();
-    Task RollbackAsync();
     IUserRepository UserRepository { get; }
     IUserRoleRepository UserRoleRepository { get; }
     IPersonRepository PersonRepository { get; }

--- a/src/UnitOfWork/UnitOfWorkEFCore.cs
+++ b/src/UnitOfWork/UnitOfWorkEFCore.cs
@@ -9,9 +9,12 @@ public partial class UnitOfWorkEFCore : IUnitOfWork
         _context = context;
     }
 
+    public IAppDbContextTransaction BeginTransaction()
+        => new AppDbContextTransactionEFCore(_context.Database.BeginTransaction());
+
+    public async Task<IAppDbContextTransaction> BeginTransactionAsync()
+        => new AppDbContextTransactionEFCore(await _context.Database.BeginTransactionAsync());
+
     public async Task<int> SaveChangesAsync()
         => await _context.SaveChangesAsync();
-
-    public async Task RollbackAsync()
-        => await _context.Database.RollbackTransactionAsync();
 }


### PR DESCRIPTION
Fixed the problem of UPDATE operations being executed in different transactions. This causes problems when the second UPDATE operation fails, it never rollback the changes of the previous UPDATE operation.

The solution to this problem is that both UPDATE operations are executed in the same transaction.