### PR TITLE
Removed `EnvKey` attribute from `AppSettings`

### DIFF
--- a/src/Configuration/AppSettings.cs
+++ b/src/Configuration/AppSettings.cs
@@ -5,69 +5,29 @@ public class AppSettings
     public const string MaxDateInDateInput = "MAX_DATE_IN_DATE_INPUT";
     public const string BusinessName = "BUSINESS_NAME";
 
-    [EnvKey("CONNECTION_STRING")]
     public string ConnectionString { get; set; }
-
-    [EnvKey("ACCESS_TOKEN_KEY")]
     public string AccessTokenKey { get; set; }
-
-    [EnvKey("ACCESS_TOKEN_EXPIRES")]
     public double AccessTokenExpires { get; set; }
-
-    [EnvKey("EMAIL_VERIFICATION_TOKEN_KEY")]
     public string EmailVerificationTokenKey { get; set; }
-
-    [EnvKey("EMAIL_VERIFICATION_TOKEN_EXPIRES")]
     public double EmailVerificationTokenExpires { get; set; }
-
-    [EnvKey("EMAIL_VERIFICATION_URL")]
     public string EmailVerificationUrl { get; set; }
-
-    [EnvKey("PASSWORD_RESET_TOKEN_EXPIRES")]
     public double PasswordResetTokenExpires { get; set; }
-
-    [EnvKey("PASSWORD_RESET_URL")]
     public string PasswordResetUrl { get; set; }
-
-    [EnvKey("REFRESH_TOKEN_EXPIRES")]
     public double RefreshTokenExpires { get; set; }
-
     [EnvKey("SENDGRID_API_KEY")]
     public string SendGridApiKey { get; set; }
-
     [EnvKey("SENDGRID_FROM_EMAIL")]
     public string SendGridFromEmail { get; set; }
-
     [EnvKey("SENDGRID_FROM_NAME")]
     public string SendGridFromName { get; set; }
-
-    [EnvKey("TWILIO_ACCOUNT_SID")]
     public string TwilioAccountSid { get; set; }
-
-    [EnvKey("TWILIO_AUTH_TOKEN")]
     public string TwilioAuthToken { get; set; }
-
-    [EnvKey("TWILIO_FROM_NUMBER")]
     public string TwilioFromNumber { get; set; }
-
-    [EnvKey("DEFAULT_REGION")]
     public string DefaultRegion { get; set; }
-
-    [EnvKey("DENTAL_SERVICES_IMAGES_PATH")]
     public string DentalServicesImagesPath { get; set; }
-
-    [EnvKey("REMINDER_DUE_TIME")]
     public double ReminderDueTime { get; set; }
-
-    [EnvKey("REMINDER_PERIOD")]
     public double ReminderPeriod { get; set; }
-
-    [EnvKey("REMINDER_TIME_IN_ADVANCE")]
     public int ReminderTimeInAdvance { get; set; }
-
-    [EnvKey("REMINDER_HOUR_MAX")]
     public int ReminderHourMax { get; set; }
-
-    [EnvKey("REMINDER_HOUR_MIN")]
     public int ReminderHourMin { get; set; }
 }

--- a/src/DentallApp.csproj
+++ b/src/DentallApp.csproj
@@ -27,7 +27,7 @@
     <PackageReference Include="Scriban" Version="5.5.0" />
     <PackageReference Include="SendGrid.Extensions.DependencyInjection" Version="1.0.1" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.3.1" />
-    <PackageReference Include="DotEnv.Core" Version="2.2.1" />
+    <PackageReference Include="DotEnv.Core" Version="2.3.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="5.0.10">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
**dotenv.core(v2.3.0)** performs an additional step: It converts the property name to `UpperCaseSnakeCase` and then checks if it exists in the environment.

PD: I had to recreate this new PR because I deleted the **dev** branch by accident and it lost the **merged changes** in the PR #80.