### PR TITLE
Avoid initializing the integration of LINQ To DB with EF Core in each class

### DIFF
--- a/src/Extensions/DbContext.cs
+++ b/src/Extensions/DbContext.cs
@@ -1,9 +1,12 @@
-﻿namespace DentallApp.Extensions;
+﻿using LinqToDB.EntityFrameworkCore;
+
+namespace DentallApp.Extensions;
 
 public static class DbContext
 {
     public static IServiceCollection AddDbContext(this IServiceCollection services, AppSettings settings)
     {
+        LinqToDBForEFTools.Initialize();
         var cs = settings.ConnectionString;
         services.AddDbContext<AppDbContext>(options =>
         {

--- a/src/Features/AppoinmentReminders/AppoinmentReminderRepository.cs
+++ b/src/Features/AppoinmentReminders/AppoinmentReminderRepository.cs
@@ -1,16 +1,10 @@
 ﻿using LinqToDB;
-using LinqToDB.EntityFrameworkCore;
 
 namespace DentallApp.Features.AppoinmentReminders;
 
 public class AppoinmentReminderRepository : IAppoinmentReminderRepository
 {
     private readonly AppDbContext _context;
-
-    static AppoinmentReminderRepository()
-    {
-        LinqToDBForEFTools.Initialize();
-    }
 
     public AppoinmentReminderRepository(AppDbContext context)
     {

--- a/src/Features/Appoinments/AppoinmentRepository.cs
+++ b/src/Features/Appoinments/AppoinmentRepository.cs
@@ -5,11 +5,6 @@ namespace DentallApp.Features.Appoinments;
 
 public class AppoinmentRepository : Repository<Appoinment>, IAppoinmentRepository
 {
-    static AppoinmentRepository()
-    {
-        LinqToDBForEFTools.Initialize();
-    }
-
     public AppoinmentRepository(AppDbContext context) : base(context) { }
 
     public async Task<IEnumerable<AppoinmentGetByBasicUserDto>> GetAppoinmentsByUserIdAsync(int userId)

--- a/src/Features/Offices/OfficeRepository.cs
+++ b/src/Features/Offices/OfficeRepository.cs
@@ -4,11 +4,6 @@ namespace DentallApp.Features.Offices;
 
 public class OfficeRepository : SoftDeleteRepository<Office>, IOfficeRepository
 {
-    static OfficeRepository()
-    {
-        LinqToDBForEFTools.Initialize();
-    }
-
     public OfficeRepository(AppDbContext context) : base(context) { }
 
     public async Task<Office> GetOfficeByIdAsync(int id)


### PR DESCRIPTION
Resolves #76.