### PR TITLE
Change private property to a private field

### DIFF
--- a/src/DataAccess/DbConnectors/MariaDbConnector.cs
+++ b/src/DataAccess/DbConnectors/MariaDbConnector.cs
@@ -4,13 +4,11 @@ namespace DentallApp.DataAccess.DbConnectors;
 
 public class MariaDbConnector : IDbConnector
 {
-    private string ConnectionString { get; }
+    private readonly string _connectionString;
 
     public MariaDbConnector(string connectionString)
-    {
-        ConnectionString = connectionString;
-    }
+        => _connectionString = connectionString;
 
     public IDbConnection CreateConnection()
-        => new MySqlConnection(ConnectionString);
+        => new MySqlConnection(_connectionString);
 }


### PR DESCRIPTION
There is no utility in using a private property, because no additional logic is added in the getter.