### PR TITLE
Removed the feature of sending appointment information to the patient by WhatsApp

### DIFF
--- a/src/Extensions/ApplicationDependencies.cs
+++ b/src/Extensions/ApplicationDependencies.cs
@@ -20,7 +20,6 @@ public static class ApplicationDependencies
                 .AddScoped<IRoleService, RoleService>()
                 .AddScoped<IOfficeService, OfficeService>()
                 .AddScoped<IAppointmentService, AppointmentService>()
-                .AddScoped<IAppointmentInformationSendingService, AppointmentInformationSendingService>()
                 .AddScoped<IAppointmentCancellationService, AppointmentCancellationService>()
                 .AddScoped<IEmployeeScheduleService, EmployeeScheduleService>()
                 .AddScoped<IFavoriteDentistService, FavoriteDentistService>()

--- a/src/Features/Appointments/AppointmentService.cs
+++ b/src/Features/Appointments/AppointmentService.cs
@@ -3,15 +3,12 @@
 public class AppointmentService : IAppointmentService
 {
     private readonly IAppointmentRepository _appointmentRepository;
-    private readonly IAppointmentInformationSendingService _sendingService;
     private readonly IDateTimeProvider _dateTimeProvider;
 
     public AppointmentService(IAppointmentRepository appointmentRepository,
-                              IAppointmentInformationSendingService sendingService,
                               IDateTimeProvider dateTimeProvider)
     {
         _appointmentRepository = appointmentRepository;
-        _sendingService = sendingService;
         _dateTimeProvider = dateTimeProvider;
     }
 
@@ -23,7 +20,6 @@ public class AppointmentService : IAppointmentService
         var appointment = appointmentInsertDto.MapToAppointment();
         _appointmentRepository.Insert(appointment);
         await _appointmentRepository.SaveAsync();
-        await _sendingService.SendAppointmentInformationAsync(appointment.Id, appointmentInsertDto);
         return new Response<DtoBase>
         {
             Data    = new DtoBase { Id = appointment.Id },

--- a/src/Features/Appointments/Notification/AppointmentInformationSendingService.cs
+++ b/src/Features/Appointments/Notification/AppointmentInformationSendingService.cs
@@ -17,7 +17,7 @@ public class AppointmentInformationSendingService : IAppointmentInformationSendi
 
     public async Task SendAppointmentInformationAsync(int appointmentId, AppointmentInsertDto appointmentInsertDto)
     {
-        // La consulta se ejecuta en caso que se realice el agendamiento de forma manual.
+        // The query is executed in case the scheduling of appointments is done manually by the secretary.
         appointmentInsertDto.RangeToPay ??= await _treatmentRepository.GetTreatmentWithRangeToPayAsync(appointmentInsertDto.GeneralTreatmentId);
         var businessName = EnvReader.Instance[AppSettings.BusinessName];
         var info = await _appointmentRepository.GetAppointmentInformationAsync(appointmentId);


### PR DESCRIPTION
**It was decided to remove this feature for several reasons:**
- The basic user can view the appointment information from the web application.
- We have not found an easy and efficient way on how to get the **title** of the option selected by the user from the chatbot. The current code makes another call to the database to get the appointment information, when this should not be the case, it is inefficient.

**It is true that this functionality has a benefit:**
- In case the basic user schedules an appointment for a dependent, the appointment information would reach the dependent's WhatsApp (e.g., a family member or friend).

PD: The code of the functionality has not been completely removed, in case the code is refactored.