### PR TITLE
Fixed signature validation failed

### DIFF
--- a/src/Extensions/AuthenticationJwtBearer.cs
+++ b/src/Extensions/AuthenticationJwtBearer.cs
@@ -9,7 +9,7 @@ public static class AuthenticationJwtBearer
             options.DefaultAuthenticateScheme = JwtBearerDefaults.AuthenticationScheme;
             options.DefaultChallengeScheme    = JwtBearerDefaults.AuthenticationScheme;
         })
-        .AddJwtBearer(options =>
+        .AddCustomJwtBearer(options =>
         {
             options.RequireHttpsMetadata = false;
             options.SaveToken = true;
@@ -25,5 +25,21 @@ public static class AuthenticationJwtBearer
         });
         services.AddAuthorization();
         return services;
+    }
+
+    private static AuthenticationBuilder AddCustomJwtBearer(this AuthenticationBuilder builder, Action<JwtBearerOptions> configureOptions)
+        => builder.AddScheme<JwtBearerOptions, CustomJwtBearerHandler>(JwtBearerDefaults.AuthenticationScheme, displayName: null, configureOptions);
+
+    private class CustomJwtBearerHandler : JwtBearerHandler
+    {
+        public CustomJwtBearerHandler(IOptionsMonitor<JwtBearerOptions> options, ILoggerFactory logger, UrlEncoder encoder, ISystemClock clock)
+            : base(options, logger, encoder, clock) { }
+
+        // This class was created so that when DirectLine channel sends a request to the bot, it does not throw an exception:
+        // SecurityTokenSignatureKeyNotFoundException.
+        protected override async Task<AuthenticateResult> HandleAuthenticateAsync()
+            => Context.Request.Path.StartsWithSegments("/messages") ? 
+                AuthenticateResult.NoResult() : 
+                await base.HandleAuthenticateAsync();
     }
 }

--- a/src/Extensions/AuthenticationJwtBearer.cs
+++ b/src/Extensions/AuthenticationJwtBearer.cs
@@ -30,13 +30,17 @@ public static class AuthenticationJwtBearer
     private static AuthenticationBuilder AddCustomJwtBearer(this AuthenticationBuilder builder, Action<JwtBearerOptions> configureOptions)
         => builder.AddScheme<JwtBearerOptions, CustomJwtBearerHandler>(JwtBearerDefaults.AuthenticationScheme, displayName: null, configureOptions);
 
+    /// <inheritdoc />
+    /// <remarks>
+    /// This custom class was created so that when DirectLine channel sends a request to the bot, it does not throw an exception:
+    /// <see cref="SecurityTokenSignatureKeyNotFoundException" />.
+    /// <para>See issue <see href="https://github.com/DentallApp/back-end/issues/135">#135</see>.</para>
+    /// </remarks>
     private class CustomJwtBearerHandler : JwtBearerHandler
     {
         public CustomJwtBearerHandler(IOptionsMonitor<JwtBearerOptions> options, ILoggerFactory logger, UrlEncoder encoder, ISystemClock clock)
             : base(options, logger, encoder, clock) { }
 
-        // This class was created so that when DirectLine channel sends a request to the bot, it does not throw an exception:
-        // SecurityTokenSignatureKeyNotFoundException.
         protected override async Task<AuthenticateResult> HandleAuthenticateAsync()
             => Context.Request.Path.StartsWithSegments("/messages") ? 
                 AuthenticateResult.NoResult() : 

--- a/src/Extensions/AuthenticationJwtBearer.cs
+++ b/src/Extensions/AuthenticationJwtBearer.cs
@@ -38,11 +38,16 @@ public static class AuthenticationJwtBearer
     /// </remarks>
     private class CustomJwtBearerHandler : JwtBearerHandler
     {
+        /// <summary>
+        /// Path associated to the bot.
+        /// </summary>
+        private const string BotPath = "/messages";
+
         public CustomJwtBearerHandler(IOptionsMonitor<JwtBearerOptions> options, ILoggerFactory logger, UrlEncoder encoder, ISystemClock clock)
             : base(options, logger, encoder, clock) { }
 
         protected override async Task<AuthenticateResult> HandleAuthenticateAsync()
-            => Context.Request.Path.StartsWithSegments("/messages") ? 
+            => Context.Request.Path.StartsWithSegments(BotPath) ? 
                 AuthenticateResult.NoResult() : 
                 await base.HandleAuthenticateAsync();
     }

--- a/src/GlobalUsings.cs
+++ b/src/GlobalUsings.cs
@@ -89,6 +89,7 @@ global using static DentallApp.Constants.MessageTemplates;
 
 global using System.Data;
 global using System.Text;
+global using System.Text.Encodings.Web;
 global using System.Linq.Expressions;
 global using System.Reflection;
 global using System.Security.Claims;
@@ -106,6 +107,7 @@ global using Microsoft.Bot.Connector.Authentication;
 global using AdaptiveCards;
 
 global using Microsoft.AspNetCore.Mvc;
+global using Microsoft.AspNetCore.Authentication;
 global using Microsoft.AspNetCore.Authentication.JwtBearer;
 global using Microsoft.AspNetCore.Authorization;
 
@@ -118,6 +120,7 @@ global using Microsoft.EntityFrameworkCore.Storage;
 global using Microsoft.IdentityModel.Tokens;
 global using Microsoft.IdentityModel.Logging;
 global using Microsoft.OpenApi.Models;
+global using Microsoft.Extensions.Options;
 
 global using Newtonsoft.Json.Linq;
 global using Newtonsoft.Json;


### PR DESCRIPTION
The problem was that the **JwtBearerHandler** class was validating the token sent by [DirectLine](https://learn.microsoft.com/en-us/azure/bot-service/rest-api/bot-framework-rest-direct-line-3-0-api-reference?view=azure-bot-service-4.0) (token signed with the bot password) with the secret key used to sign the access token, so the validation was failing. 

The solution is based on ignoring token validation when the path is `/messages` (this is the path used for the bot).