### PR TITLE
Added new unit tests for the bot

### DIFF
--- a/tests/DentallApp.UnitTests/Features/Chatbot/Dialogs/RootDialogTests.Validation.cs
+++ b/tests/DentallApp.UnitTests/Features/Chatbot/Dialogs/RootDialogTests.Validation.cs
@@ -89,4 +89,80 @@ public partial class RootDialogTests
         Assert.AreEqual(expected: SelectScheduleMessage, actual: reply.Text);
         _testClient.GetNextReply<IMessageActivity>();
     }
+
+    [TestMethod]
+    public async Task Bot_WhenThereAreNoHoursAvailable_ShouldSendAnErrorMessage()
+    {
+        Mock.Arrange(() => _botService.GetAvailableHoursAsync(Arg.IsAny<AvailableTimeRangePostDto>()))
+            .ReturnsAsync(new Response<IEnumerable<AvailableTimeRangeDto>>
+            {
+                Success = false,
+                Message = NoSchedulesAvailableMessage
+            });
+
+        await _testClient.SendActivityAsync<IMessageActivity>(CreateInitialActivity());
+        _testClient.GetNextReply<IMessageActivity>();
+
+        await _testClient.SendActivityAsync<IMessageActivity>(CreateActivityWithSelectedPatientId());
+        _testClient.GetNextReply<IMessageActivity>();
+
+        await _testClient.SendActivityAsync<IMessageActivity>(CreateActivityWithSelectedOfficeId());
+        _testClient.GetNextReply<IMessageActivity>();
+
+        await _testClient.SendActivityAsync<IMessageActivity>(CreateActivityWithSelectedDentalServiceId());
+        _testClient.GetNextReply<IMessageActivity>();
+
+        Environment.SetEnvironmentVariable(AppSettings.MaxDaysInCalendar, "60");
+        await _testClient.SendActivityAsync<IMessageActivity>(CreateActivityWithSelectedDentistId());
+        _testClient.GetNextReply<IMessageActivity>();
+        _testClient.GetNextReply<IMessageActivity>();
+
+        await _testClient.SendActivityAsync<IMessageActivity>(CreateActivityWithSelectedDate());
+        _testClient.GetNextReply<IMessageActivity>();
+        var replyNext = _testClient.GetNextReply<IMessageActivity>();
+        Assert.AreEqual(expected: ActivityTypes.Message, actual: replyNext.Type);
+        Assert.AreEqual(expected: NoSchedulesAvailableMessage, actual: replyNext.Text);
+        replyNext = _testClient.GetNextReply<IMessageActivity>();
+        Assert.AreEqual(expected: ActivityTypes.Message, actual: replyNext.Type);
+    }
+
+    [TestMethod]
+    public async Task Bot_WhenDateAndTimeAppointmentIsNotAvailable_ShouldSendAnErrorMessage()
+    {
+        Mock.Arrange(() => _botService.CreateScheduledAppointmentAsync(Arg.IsAny<AppointmentInsertDto>()))
+            .ReturnsAsync(new Response<DtoBase>
+            {
+                Success = false,
+                Message = DateAndTimeAppointmentIsNotAvailableMessage
+            });
+
+        await _testClient.SendActivityAsync<IMessageActivity>(CreateInitialActivity());
+        _testClient.GetNextReply<IMessageActivity>();
+
+        await _testClient.SendActivityAsync<IMessageActivity>(CreateActivityWithSelectedPatientId());
+        _testClient.GetNextReply<IMessageActivity>();
+
+        await _testClient.SendActivityAsync<IMessageActivity>(CreateActivityWithSelectedOfficeId());
+        _testClient.GetNextReply<IMessageActivity>();
+
+        await _testClient.SendActivityAsync<IMessageActivity>(CreateActivityWithSelectedDentalServiceId());
+        _testClient.GetNextReply<IMessageActivity>();
+
+        Environment.SetEnvironmentVariable(AppSettings.MaxDaysInCalendar, "60");
+        await _testClient.SendActivityAsync<IMessageActivity>(CreateActivityWithSelectedDentistId());
+        _testClient.GetNextReply<IMessageActivity>();
+        _testClient.GetNextReply<IMessageActivity>();
+
+        await _testClient.SendActivityAsync<IMessageActivity>(CreateActivityWithSelectedDate());
+        _testClient.GetNextReply<IMessageActivity>();
+        _testClient.GetNextReply<IMessageActivity>();
+
+        await _testClient.SendActivityAsync<IMessageActivity>(CreateActivityWithSelectedSchedule());
+        _testClient.GetNextReply<IMessageActivity>();
+        var replyNext = _testClient.GetNextReply<IMessageActivity>();
+        Assert.AreEqual(expected: ActivityTypes.Message, actual: replyNext.Type);
+        Assert.AreEqual(expected: DateAndTimeAppointmentIsNotAvailableMessage, actual: replyNext.Text);
+        replyNext = _testClient.GetNextReply<IMessageActivity>();
+        Assert.AreEqual(expected: ActivityTypes.Message, actual: replyNext.Type);
+    }
 }

--- a/tests/DentallApp.UnitTests/Features/Chatbot/Dialogs/RootDialogTests.cs
+++ b/tests/DentallApp.UnitTests/Features/Chatbot/Dialogs/RootDialogTests.cs
@@ -5,13 +5,14 @@ public partial class RootDialogTests
 {
     private DialogTestClient _testClient;
     private IDateTimeProvider _dateTimeProvider;
+    private IAppointmentBotService _botService;
 
     [TestInitialize]
     public void TestInitialize()
     {
-        var botService    = CreateMock();
+        _botService       = CreateMock();
         _dateTimeProvider = Mock.Create<IDateTimeProvider>();
-        _testClient = new(Channels.Webchat, new RootDialog(botService, _dateTimeProvider));
+        _testClient       = new(Channels.Webchat, new RootDialog(_botService, _dateTimeProvider));
     }
 
     [TestMethod]


### PR DESCRIPTION
- Checks if the bot returns an error message when there are no available schedules.
- Checks if the bot returns an error message when the date and time of the appointment is not available.

Related to PR #131.