### PR TITLE
 Added the bot dialog tests to the integration test project

### DIFF
--- a/DentallApp.sln
+++ b/DentallApp.sln
@@ -5,7 +5,9 @@ VisualStudioVersion = 16.0.30114.105
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DentallApp", "src\DentallApp.csproj", "{E354A181-1E6C-4F76-8D99-96E5A6824FC1}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DentallApp.Tests", "tests\DentallApp.UnitTests\DentallApp.UnitTests.csproj", "{BE6318A1-900B-4E8E-8AAE-C391F881C844}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DentallApp.UnitTests", "tests\DentallApp.UnitTests\DentallApp.UnitTests.csproj", "{BE6318A1-900B-4E8E-8AAE-C391F881C844}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DentallApp.IntegrationTests", "tests\DentallApp.IntegrationTests\DentallApp.IntegrationTests.csproj", "{3897DDB9-5C4F-4664-94D7-756A5E673951}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -24,5 +26,9 @@ Global
 		{BE6318A1-900B-4E8E-8AAE-C391F881C844}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{BE6318A1-900B-4E8E-8AAE-C391F881C844}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{BE6318A1-900B-4E8E-8AAE-C391F881C844}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3897DDB9-5C4F-4664-94D7-756A5E673951}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3897DDB9-5C4F-4664-94D7-756A5E673951}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3897DDB9-5C4F-4664-94D7-756A5E673951}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3897DDB9-5C4F-4664-94D7-756A5E673951}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal

--- a/tests/DentallApp.IntegrationTests/DentallApp.IntegrationTests.csproj
+++ b/tests/DentallApp.IntegrationTests/DentallApp.IntegrationTests.csproj
@@ -1,0 +1,29 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net7.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>disable</Nullable>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.msbuild" Version="3.1.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="FluentAssertions" Version="6.10.0" />
+    <PackageReference Include="JustMock" Version="2023.1.117.1" />
+    <PackageReference Include="Microsoft.Bot.Builder.Testing" Version="4.18.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
+    <PackageReference Include="NUnit" Version="3.13.3" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.3.0" />
+    <PackageReference Include="NUnit.Analyzers" Version="3.5.0" />
+  </ItemGroup>
+  
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\DentallApp.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/DentallApp.IntegrationTests/Features/Chatbot/Dialogs/ActivityFactory.cs
+++ b/tests/DentallApp.IntegrationTests/Features/Chatbot/Dialogs/ActivityFactory.cs
@@ -1,4 +1,4 @@
-﻿namespace DentallApp.UnitTests.Features.Chatbot.Dialogs;
+﻿namespace DentallApp.IntegrationTests.Features.Chatbot.Dialogs;
 
 public static class ActivityFactory
 {

--- a/tests/DentallApp.IntegrationTests/Features/Chatbot/Dialogs/BotServiceMockFactory.cs
+++ b/tests/DentallApp.IntegrationTests/Features/Chatbot/Dialogs/BotServiceMockFactory.cs
@@ -1,4 +1,4 @@
-﻿namespace DentallApp.UnitTests.Features.Chatbot.Dialogs;
+﻿namespace DentallApp.IntegrationTests.Features.Chatbot.Dialogs;
 
 public static class BotServiceMockFactory
 {

--- a/tests/DentallApp.IntegrationTests/Features/Chatbot/Dialogs/BotServiceMockFactory.cs
+++ b/tests/DentallApp.IntegrationTests/Features/Chatbot/Dialogs/BotServiceMockFactory.cs
@@ -13,7 +13,7 @@ public static class BotServiceMockFactory
     public const int PriceMin             = 5;
     public const int PriceMax             = 10;
 
-    public static IAppointmentBotService CreateMock()
+    public static IAppointmentBotService CreateBotServiceMock()
     {
         var botService = Mock.Create<IAppointmentBotService>();
         Mock.Arrange(() => botService.GetPatientsAsync(Arg.IsAny<UserProfile>()))

--- a/tests/DentallApp.IntegrationTests/Features/Chatbot/Dialogs/RootDialogTests.Validation.cs
+++ b/tests/DentallApp.IntegrationTests/Features/Chatbot/Dialogs/RootDialogTests.Validation.cs
@@ -1,4 +1,4 @@
-﻿namespace DentallApp.UnitTests.Features.Chatbot.Dialogs;
+﻿namespace DentallApp.IntegrationTests.Features.Chatbot.Dialogs;
 
 public partial class RootDialogTests
 {

--- a/tests/DentallApp.IntegrationTests/Features/Chatbot/Dialogs/RootDialogTests.Validation.cs
+++ b/tests/DentallApp.IntegrationTests/Features/Chatbot/Dialogs/RootDialogTests.Validation.cs
@@ -26,7 +26,6 @@ public partial class RootDialogTests
         reply = await _testClient.SendActivityAsync<IMessageActivity>(incomingActivity);
         reply.Text.Should().Be(SelectDentistMessage);
 
-        Environment.SetEnvironmentVariable(AppSettings.MaxDaysInCalendar, "60");
         await _testClient.SendActivityAsync<IMessageActivity>(CreateActivityWithSelectedDentistId());
         _testClient.GetNextReply<IMessageActivity>();
         _testClient.GetNextReply<IMessageActivity>();
@@ -72,7 +71,6 @@ public partial class RootDialogTests
         reply.Text.Should().Be(SelectDentistMessage);
         _testClient.GetNextReply<IMessageActivity>();
 
-        Environment.SetEnvironmentVariable(AppSettings.MaxDaysInCalendar, "60");
         await _testClient.SendActivityAsync<IMessageActivity>(CreateActivityWithSelectedDentistId());
         _testClient.GetNextReply<IMessageActivity>();
         _testClient.GetNextReply<IMessageActivity>();
@@ -112,7 +110,6 @@ public partial class RootDialogTests
         await _testClient.SendActivityAsync<IMessageActivity>(CreateActivityWithSelectedDentalServiceId());
         _testClient.GetNextReply<IMessageActivity>();
 
-        Environment.SetEnvironmentVariable(AppSettings.MaxDaysInCalendar, "60");
         await _testClient.SendActivityAsync<IMessageActivity>(CreateActivityWithSelectedDentistId());
         _testClient.GetNextReply<IMessageActivity>();
         _testClient.GetNextReply<IMessageActivity>();
@@ -148,7 +145,6 @@ public partial class RootDialogTests
         await _testClient.SendActivityAsync<IMessageActivity>(CreateActivityWithSelectedDentalServiceId());
         _testClient.GetNextReply<IMessageActivity>();
 
-        Environment.SetEnvironmentVariable(AppSettings.MaxDaysInCalendar, "60");
         await _testClient.SendActivityAsync<IMessageActivity>(CreateActivityWithSelectedDentistId());
         _testClient.GetNextReply<IMessageActivity>();
         _testClient.GetNextReply<IMessageActivity>();

--- a/tests/DentallApp.IntegrationTests/Features/Chatbot/Dialogs/RootDialogTests.cs
+++ b/tests/DentallApp.IntegrationTests/Features/Chatbot/Dialogs/RootDialogTests.cs
@@ -12,6 +12,7 @@ public partial class RootDialogTests
         _botService       = CreateMock();
         _dateTimeProvider = Mock.Create<IDateTimeProvider>();
         _testClient       = new(Channels.Webchat, new RootDialog(_botService, _dateTimeProvider));
+        Environment.SetEnvironmentVariable(AppSettings.MaxDaysInCalendar, "60");
     }
 
     [TestCase]
@@ -49,7 +50,6 @@ public partial class RootDialogTests
 
     private async Task SendReplyWithInputDateAsync(Activity incomingActivity)
     {
-        Environment.SetEnvironmentVariable(AppSettings.MaxDaysInCalendar, "60");
         Mock.Arrange(() => _dateTimeProvider.Now).Returns(new DateTime(2023, 01, 01));
 
         var reply     = await _testClient.SendActivityAsync<IMessageActivity>(incomingActivity);

--- a/tests/DentallApp.IntegrationTests/Features/Chatbot/Dialogs/RootDialogTests.cs
+++ b/tests/DentallApp.IntegrationTests/Features/Chatbot/Dialogs/RootDialogTests.cs
@@ -1,4 +1,4 @@
-﻿namespace DentallApp.UnitTests.Features.Chatbot.Dialogs;
+﻿namespace DentallApp.IntegrationTests.Features.Chatbot.Dialogs;
 
 public partial class RootDialogTests
 {

--- a/tests/DentallApp.IntegrationTests/Features/Chatbot/Dialogs/RootDialogTests.cs
+++ b/tests/DentallApp.IntegrationTests/Features/Chatbot/Dialogs/RootDialogTests.cs
@@ -9,7 +9,7 @@ public partial class RootDialogTests
     [SetUp]
     public void TestInitialize()
     {
-        _botService       = CreateMock();
+        _botService       = CreateBotServiceMock();
         _dateTimeProvider = Mock.Create<IDateTimeProvider>();
         _testClient       = new(Channels.Webchat, new RootDialog(_botService, _dateTimeProvider));
         Environment.SetEnvironmentVariable(AppSettings.MaxDaysInCalendar, "60");

--- a/tests/DentallApp.IntegrationTests/GlobalUsings.cs
+++ b/tests/DentallApp.IntegrationTests/GlobalUsings.cs
@@ -1,0 +1,3 @@
+global using NUnit.Framework;
+global using FluentAssertions;
+global using Microsoft.Bot.Builder.Testing;

--- a/tests/DentallApp.IntegrationTests/GlobalUsings.cs
+++ b/tests/DentallApp.IntegrationTests/GlobalUsings.cs
@@ -1,3 +1,23 @@
 global using NUnit.Framework;
 global using FluentAssertions;
+global using Telerik.JustMock;
+global using AdaptiveCards;
+global using Microsoft.Bot.Connector;
 global using Microsoft.Bot.Builder.Testing;
+global using Microsoft.Bot.Schema;
+global using Newtonsoft.Json.Linq;
+
+global using static DentallApp.IntegrationTests.Features.Chatbot.Dialogs.BotServiceMockFactory;
+global using static DentallApp.IntegrationTests.Features.Chatbot.Dialogs.ActivityFactory;
+
+global using DentallApp.Features.Chatbot;
+global using DentallApp.Features.Chatbot.Models;
+global using DentallApp.Features.Chatbot.Dialogs;
+global using DentallApp.Features.Appointments.DTOs;
+global using DentallApp.Features.SpecificTreatments.DTOs;
+global using DentallApp.Features.AvailabilityHours.DTOs;
+
+global using DentallApp.Responses;
+global using DentallApp.Configuration;
+global using DentallApp.Helpers.DateTimeHelpers;
+global using static DentallApp.Constants.ResponseMessages;

--- a/tests/DentallApp.UnitTests/DentallApp.UnitTests.csproj
+++ b/tests/DentallApp.UnitTests/DentallApp.UnitTests.csproj
@@ -14,8 +14,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="FluentAssertions" Version="6.10.0" />
-    <PackageReference Include="JustMock" Version="2022.3.912.3" />
-    <PackageReference Include="Microsoft.Bot.Builder.Testing" Version="4.18.1" />
+    <PackageReference Include="JustMock" Version="2023.1.117.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.3.0" />

--- a/tests/DentallApp.UnitTests/GlobalUsings.cs
+++ b/tests/DentallApp.UnitTests/GlobalUsings.cs
@@ -1,13 +1,9 @@
 global using System.Collections;
 global using NUnit.Framework;
 global using FluentAssertions;
-global using AdaptiveCards;
-global using Microsoft.Bot.Connector;
 global using Microsoft.Bot.Schema;
-global using Microsoft.Bot.Builder.Testing;
 global using Telerik.JustMock;
 global using System.Security.Claims;
-global using Newtonsoft.Json.Linq;
 global using DotEnv.Core;
 
 global using DentallApp.Features.AvailabilityHours;
@@ -19,15 +15,11 @@ global using DentallApp.Features.AppointmentCancellation.DTOs;
 global using DentallApp.Features.SecurityToken;
 global using DentallApp.Features.Roles;
 global using DentallApp.Features.Appointments;
-global using DentallApp.Features.Appointments.DTOs;
 global using DentallApp.Features.EmployeeSchedules;
 global using DentallApp.Features.EmployeeSchedules.DTOs;
 global using DentallApp.Features.GeneralTreatments;
 global using DentallApp.Features.GeneralTreatments.DTOs;
-global using DentallApp.Features.SpecificTreatments.DTOs;
 global using DentallApp.Features.PublicHolidays.Offices;
-global using DentallApp.Features.Chatbot;
-global using DentallApp.Features.Chatbot.Dialogs;
 global using DentallApp.Features.Chatbot.Models;
 global using DentallApp.Features.Chatbot.DirectLine;
 global using DentallApp.Features.Chatbot.DirectLine.Services;
@@ -37,9 +29,4 @@ global using DentallApp.Helpers.InstantMessaging;
 global using DentallApp.Helpers.DateTimeHelpers;
 global using DentallApp.Configuration;
 global using DentallApp.DataAccess.Repositories;
-global using DentallApp.Responses;
 global using static DentallApp.Constants.ResponseMessages;
-
-global using static DentallApp.UnitTests.Features.Chatbot.Dialogs.BotServiceMockFactory;
-global using static DentallApp.UnitTests.Features.Chatbot.Dialogs.ActivityFactory;
-


### PR DESCRIPTION
The bot dialog tests with the client depend on the file system to load the adaptive cards (they are json files) at each turn, so it is consistent to consider it as an integration test rather than a unit test.

Resolves #176.