### PR TITLE
 refactor: Create strongly typed objects to encapsulate error and success messages

### DIFF
--- a/src/Features/Appointments/UseCases/CancelAppointments.cs
+++ b/src/Features/Appointments/UseCases/CancelAppointments.cs
@@ -54,8 +54,8 @@ public class CancelAppointmentsUseCase(
         // Verify if there are appointments that cannot be cancelled.
         if (request.Appointments.Count() != appointmentsCanBeCancelled.Count())
         {
-            int count = request.Appointments.Count() - appointmentsCanBeCancelled.Count();
-            var message = string.Format(Messages.AppointmentThatHasAlreadyPassedEmployee, count);
+            int pastAppointments = request.Appointments.Count() - appointmentsCanBeCancelled.Count();
+            var message = new AppointmentThatHasAlreadyPassedEmployeeError(pastAppointments).Message;
             var appointmentsThatCannotBeCanceled = new CancelAppointmentsResponse
             {
                 AppointmentsId = request.Appointments

--- a/src/Features/Appointments/UseCases/GetAvailableHours/GetAvailableHours.cs
+++ b/src/Features/Appointments/UseCases/GetAvailableHours/GetAvailableHours.cs
@@ -15,10 +15,10 @@ public class GetAvailableHoursUseCase(IAvailabilityQueries queries, IDateTimeSer
 
         var employeeSchedule  = await queries.GetEmployeeScheduleAsync(dentistId, weekDayId);
         if (employeeSchedule is null || employeeSchedule.IsEmployeeScheculeDeleted)
-            return Result.Failure(string.Format(Messages.DentistNotAvailable, weekDayName));
+            return Result.Failure(new DentistNotAvailableError(weekDayName).Message);
 
         if (employeeSchedule.IsOfficeScheduleDeleted || employeeSchedule.IsOfficeDeleted)
-            return Result.Failure(string.Format(Messages.OfficeClosedForSpecificDay, weekDayName));
+            return Result.Failure(new OfficeClosedForSpecificDayError(weekDayName).Message);
 
         if (employeeSchedule.HasNotSchedule())
             return Result.Failure(Messages.NoMorningOrAfternoonHours);

--- a/src/Features/GlobalUsings.cs
+++ b/src/Features/GlobalUsings.cs
@@ -7,6 +7,7 @@ global using DentallApp.Shared.Appointments;
 global using DentallApp.Shared.Constants;
 global using DentallApp.Shared.Resources.ApiResponses;
 global using DentallApp.Shared.Resources.Kinships;
+global using DentallApp.Shared.Reasons;
 global using DentallApp.Shared.Attributes;
 global using DentallApp.Shared.Configuration;
 global using DentallApp.Shared.Extensions;

--- a/src/Features/Security/Users/UseCases/ResetForgottenPassword.cs
+++ b/src/Features/Security/Users/UseCases/ResetForgottenPassword.cs
@@ -18,7 +18,7 @@ public class ResetForgottenPasswordUseCase(
             return Result.Invalid(Messages.PasswordResetTokenInvalid);
 
         if (!claimIdentity.HasClaim(CustomClaimsType.UserId))
-            return Result.Invalid(string.Format(Messages.MissingClaim, CustomClaimsType.UserId));
+            return Result.Invalid(new MissingClaimError(CustomClaimsType.UserId).Message);
 
         var userId = claimIdentity.GetUserId();
         var user = await context.Set<User>()

--- a/src/Plugins/ChatBot/Dialogs/RootDialog.cs
+++ b/src/Plugins/ChatBot/Dialogs/RootDialog.cs
@@ -133,7 +133,7 @@ public partial class RootDialog : ComponentDialog
         await stepContext
             .Context
             .SendActivityAsync(
-                string.Format(Messages.ShowScheduleToUser, dentistSchedule),
+                new ShowScheduleToUserSuccess(dentistSchedule).Message,
                 cancellationToken: cancellationToken);
 
         return await stepContext.PromptAsync(
@@ -169,7 +169,7 @@ public partial class RootDialog : ComponentDialog
         await stepContext
             .Context
             .SendActivityAsync(
-                string.Format(Messages.TotalHoursAvailable, availableHours.Count),
+                new TotalHoursAvailableSuccess(availableHours.Count).Message,
                 cancellationToken: cancellationToken);
 
         return await stepContext.PromptAsync(
@@ -202,7 +202,7 @@ public partial class RootDialog : ComponentDialog
         await stepContext
             .Context
             .SendActivityAsync(
-                string.Format(Messages.SuccessfullyScheduledAppointment, appointment.RangeToPay?.ToString()), 
+                new SuccessfullyScheduledAppointmentSuccess(appointment.RangeToPay?.ToString()).Message, 
                 cancellationToken: cancellationToken);
 
         await stepContext.Context.SendActivityAsync(Messages.ThanksForUsingService, cancellationToken: cancellationToken);

--- a/src/Plugins/ChatBot/Dialogs/RootDialog.cs
+++ b/src/Plugins/ChatBot/Dialogs/RootDialog.cs
@@ -202,7 +202,7 @@ public partial class RootDialog : ComponentDialog
         await stepContext
             .Context
             .SendActivityAsync(
-                new SuccessfullyScheduledAppointmentSuccess(appointment.RangeToPay?.ToString()).Message, 
+                new ScheduledAppointmentSuccess(appointment.RangeToPay?.ToString()).Message, 
                 cancellationToken: cancellationToken);
 
         await stepContext.Context.SendActivityAsync(Messages.ThanksForUsingService, cancellationToken: cancellationToken);

--- a/src/Plugins/ChatBot/GlobalUsings.cs
+++ b/src/Plugins/ChatBot/GlobalUsings.cs
@@ -14,6 +14,7 @@ global using DentallApp.Shared.Domain.EmployeeSchedules;
 global using DentallApp.Shared.Appointments;
 global using DentallApp.Shared.Constants;
 global using DentallApp.Shared.Resources.ApiResponses;
+global using DentallApp.Shared.Reasons;
 global using DentallApp.Shared.Attributes;
 global using DentallApp.Shared.Configuration;
 global using DentallApp.Shared.Extensions;

--- a/src/Shared/Domain/PayRange.cs
+++ b/src/Shared/Domain/PayRange.cs
@@ -8,8 +8,8 @@ public class PayRange : ValueObject
     public override string ToString()
     {
         return PriceMin != PriceMax ?
-            string.Format(Messages.RangeToPayMinMax, PriceMin, PriceMax) :
-            string.Format(Messages.RangeToPay, PriceMax);
+            new PaymentSuccess(PriceMin, PriceMax).Message :
+            new PaymentSuccess(PriceMax).Message;
     }
 
     protected override IEnumerable<object> GetEqualityComponents()

--- a/src/Shared/GlobalUsings.cs
+++ b/src/Shared/GlobalUsings.cs
@@ -5,6 +5,7 @@ global using DentallApp.Shared.Constants;
 global using DentallApp.Shared.Resources.ApiResponses;
 global using DentallApp.Shared.Resources.Statuses;
 global using DentallApp.Shared.Resources.Weekdays;
+global using DentallApp.Shared.Reasons;
 global using DentallApp.Shared.Extensions;
 global using DentallApp.Shared.Models;
 global using DentallApp.Shared.Models.Claims;

--- a/src/Shared/Reasons/AppointmentThatHasAlreadyPassedEmployeeError.cs
+++ b/src/Shared/Reasons/AppointmentThatHasAlreadyPassedEmployeeError.cs
@@ -1,0 +1,8 @@
+﻿namespace DentallApp.Shared.Reasons;
+
+public class AppointmentThatHasAlreadyPassedEmployeeError
+{
+    public string Message { get; }
+    public AppointmentThatHasAlreadyPassedEmployeeError(int pastAppointments)
+        => Message = string.Format(Messages.AppointmentThatHasAlreadyPassedEmployee, pastAppointments);
+}

--- a/src/Shared/Reasons/AppointmentThatHasAlreadyPassedEmployeeError.cs
+++ b/src/Shared/Reasons/AppointmentThatHasAlreadyPassedEmployeeError.cs
@@ -1,6 +1,6 @@
 ﻿namespace DentallApp.Shared.Reasons;
 
-public class AppointmentThatHasAlreadyPassedEmployeeError
+public readonly ref struct AppointmentThatHasAlreadyPassedEmployeeError
 {
     public string Message { get; }
     public AppointmentThatHasAlreadyPassedEmployeeError(int pastAppointments)

--- a/src/Shared/Reasons/DentistNotAvailableError.cs
+++ b/src/Shared/Reasons/DentistNotAvailableError.cs
@@ -1,6 +1,6 @@
 ﻿namespace DentallApp.Shared.Reasons;
 
-public class DentistNotAvailableError
+public readonly ref struct DentistNotAvailableError
 {
     public string Message { get; }
     public DentistNotAvailableError(string weekDayName)

--- a/src/Shared/Reasons/DentistNotAvailableError.cs
+++ b/src/Shared/Reasons/DentistNotAvailableError.cs
@@ -1,0 +1,8 @@
+﻿namespace DentallApp.Shared.Reasons;
+
+public class DentistNotAvailableError
+{
+    public string Message { get; }
+    public DentistNotAvailableError(string weekDayName)
+        => Message = string.Format(Messages.DentistNotAvailable, weekDayName ?? string.Empty);
+}

--- a/src/Shared/Reasons/MissingClaimError.cs
+++ b/src/Shared/Reasons/MissingClaimError.cs
@@ -1,0 +1,8 @@
+﻿namespace DentallApp.Shared.Reasons;
+
+public class MissingClaimError
+{
+    public string Message { get; }
+    public MissingClaimError(string claimType)
+        => Message = string.Format(Messages.MissingClaim, claimType ?? string.Empty);
+}

--- a/src/Shared/Reasons/MissingClaimError.cs
+++ b/src/Shared/Reasons/MissingClaimError.cs
@@ -1,6 +1,6 @@
 ﻿namespace DentallApp.Shared.Reasons;
 
-public class MissingClaimError
+public readonly ref struct MissingClaimError
 {
     public string Message { get; }
     public MissingClaimError(string claimType)

--- a/src/Shared/Reasons/OfficeClosedForSpecificDayError.cs
+++ b/src/Shared/Reasons/OfficeClosedForSpecificDayError.cs
@@ -1,0 +1,8 @@
+﻿namespace DentallApp.Shared.Reasons;
+
+public class OfficeClosedForSpecificDayError
+{
+    public string Message { get; }
+    public OfficeClosedForSpecificDayError(string weekDayName)
+        => Message = string.Format(Messages.OfficeClosedForSpecificDay, weekDayName ?? string.Empty);
+}

--- a/src/Shared/Reasons/OfficeClosedForSpecificDayError.cs
+++ b/src/Shared/Reasons/OfficeClosedForSpecificDayError.cs
@@ -1,6 +1,6 @@
 ﻿namespace DentallApp.Shared.Reasons;
 
-public class OfficeClosedForSpecificDayError
+public readonly ref struct OfficeClosedForSpecificDayError
 {
     public string Message { get; }
     public OfficeClosedForSpecificDayError(string weekDayName)

--- a/src/Shared/Reasons/PaymentSuccess.cs
+++ b/src/Shared/Reasons/PaymentSuccess.cs
@@ -1,6 +1,6 @@
 ﻿namespace DentallApp.Shared.Reasons;
 
-public class PaymentSuccess
+public readonly ref struct PaymentSuccess
 {
     public string Message { get; }
 

--- a/src/Shared/Reasons/PaymentSuccess.cs
+++ b/src/Shared/Reasons/PaymentSuccess.cs
@@ -1,0 +1,12 @@
+﻿namespace DentallApp.Shared.Reasons;
+
+public class PaymentSuccess
+{
+    public string Message { get; }
+
+    public PaymentSuccess(double price)
+        => Message = string.Format(Messages.PayableValue, price);
+
+    public PaymentSuccess(double priceMin, double priceMax)
+        => Message = string.Format(Messages.RangeToPayMinMax, priceMin, priceMax);
+}

--- a/src/Shared/Reasons/ScheduledAppointmentSuccess.cs
+++ b/src/Shared/Reasons/ScheduledAppointmentSuccess.cs
@@ -1,8 +1,8 @@
 ﻿namespace DentallApp.Shared.Reasons;
 
-public readonly ref struct SuccessfullyScheduledAppointmentSuccess
+public readonly ref struct ScheduledAppointmentSuccess
 {
     public string Message { get; }
-    public SuccessfullyScheduledAppointmentSuccess(string rangeToPay)
+    public ScheduledAppointmentSuccess(string rangeToPay)
         => Message = string.Format(Messages.SuccessfullyScheduledAppointment, rangeToPay ?? string.Empty);
 }

--- a/src/Shared/Reasons/ShowScheduleToUserSuccess.cs
+++ b/src/Shared/Reasons/ShowScheduleToUserSuccess.cs
@@ -1,6 +1,6 @@
 ﻿namespace DentallApp.Shared.Reasons;
 
-public class ShowScheduleToUserSuccess
+public readonly ref struct ShowScheduleToUserSuccess
 {
     public string Message { get; }
     public ShowScheduleToUserSuccess(string dentistSchedule)

--- a/src/Shared/Reasons/ShowScheduleToUserSuccess.cs
+++ b/src/Shared/Reasons/ShowScheduleToUserSuccess.cs
@@ -1,0 +1,8 @@
+﻿namespace DentallApp.Shared.Reasons;
+
+public class ShowScheduleToUserSuccess
+{
+    public string Message { get; }
+    public ShowScheduleToUserSuccess(string dentistSchedule)
+        => Message = string.Format(Messages.ShowScheduleToUser, dentistSchedule ?? string.Empty);
+}

--- a/src/Shared/Reasons/SuccessfullyScheduledAppointmentSuccess.cs
+++ b/src/Shared/Reasons/SuccessfullyScheduledAppointmentSuccess.cs
@@ -1,0 +1,8 @@
+﻿namespace DentallApp.Shared.Reasons;
+
+public class SuccessfullyScheduledAppointmentSuccess
+{
+    public string Message { get; }
+    public SuccessfullyScheduledAppointmentSuccess(string rangeToPay)
+        => Message = string.Format(Messages.SuccessfullyScheduledAppointment, rangeToPay ?? string.Empty);
+}

--- a/src/Shared/Reasons/SuccessfullyScheduledAppointmentSuccess.cs
+++ b/src/Shared/Reasons/SuccessfullyScheduledAppointmentSuccess.cs
@@ -1,6 +1,6 @@
 ﻿namespace DentallApp.Shared.Reasons;
 
-public class SuccessfullyScheduledAppointmentSuccess
+public readonly ref struct SuccessfullyScheduledAppointmentSuccess
 {
     public string Message { get; }
     public SuccessfullyScheduledAppointmentSuccess(string rangeToPay)

--- a/src/Shared/Reasons/TotalHoursAvailableSuccess.cs
+++ b/src/Shared/Reasons/TotalHoursAvailableSuccess.cs
@@ -1,0 +1,8 @@
+﻿namespace DentallApp.Shared.Reasons;
+
+public class TotalHoursAvailableSuccess
+{
+    public string Message { get; }
+    public TotalHoursAvailableSuccess(int totalHours)
+        => Message = string.Format(Messages.TotalHoursAvailable, totalHours);
+}

--- a/src/Shared/Reasons/TotalHoursAvailableSuccess.cs
+++ b/src/Shared/Reasons/TotalHoursAvailableSuccess.cs
@@ -1,6 +1,6 @@
 ﻿namespace DentallApp.Shared.Reasons;
 
-public class TotalHoursAvailableSuccess
+public readonly ref struct TotalHoursAvailableSuccess
 {
     public string Message { get; }
     public TotalHoursAvailableSuccess(int totalHours)

--- a/src/Shared/Resources/ApiResponses/Messages.Designer.cs
+++ b/src/Shared/Resources/ApiResponses/Messages.Designer.cs
@@ -466,20 +466,20 @@ namespace DentallApp.Shared.Resources.ApiResponses {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to El valor a pagar es de ${0}.
+        /// </summary>
+        public static string PayableValue {
+            get {
+                return ResourceManager.GetString("PayableValue", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to No tienes permisos para otorgar esos roles..
         /// </summary>
         public static string PermitsNotGranted {
             get {
                 return ResourceManager.GetString("PermitsNotGranted", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to El valor a pagar es de ${0}.
-        /// </summary>
-        public static string RangeToPay {
-            get {
-                return ResourceManager.GetString("RangeToPay", resourceCulture);
             }
         }
         

--- a/src/Shared/Resources/ApiResponses/Messages.resx
+++ b/src/Shared/Resources/ApiResponses/Messages.resx
@@ -252,11 +252,11 @@
   <data name="PasswordSuccessfullyReset" xml:space="preserve">
     <value>La contraseña se ha restablecido con éxito.</value>
   </data>
+  <data name="PayableValue" xml:space="preserve">
+    <value>El valor a pagar es de ${0}</value>
+  </data>
   <data name="PermitsNotGranted" xml:space="preserve">
     <value>No tienes permisos para otorgar esos roles.</value>
-  </data>
-  <data name="RangeToPay" xml:space="preserve">
-    <value>El valor a pagar es de ${0}</value>
   </data>
   <data name="RangeToPayMinMax" xml:space="preserve">
     <value>El rango a pagar es de ${0} a ${1}</value>

--- a/tests/ChatBot/Dialogs/RootDialogTests.cs
+++ b/tests/ChatBot/Dialogs/RootDialogTests.cs
@@ -56,7 +56,7 @@ public partial class RootDialogTests
         reply.Type.Should().Be(ActivityTypes.Typing);
 
         var replyNext = _testClient.GetNextReply<IMessageActivity>();
-        replyNext.Text.Should().Be(string.Format(Messages.ShowScheduleToUser, Schedule));
+        replyNext.Text.Should().Be(new ShowScheduleToUserSuccess(Schedule).Message);
         replyNext.Type.Should().Be(ActivityTypes.Message);
 
         replyNext     = _testClient.GetNextReply<IMessageActivity>();
@@ -77,7 +77,7 @@ public partial class RootDialogTests
         reply.Type.Should().Be(ActivityTypes.Typing);
 
         var replyNext = _testClient.GetNextReply<IMessageActivity>();
-        replyNext.Text.Should().Be(string.Format(Messages.TotalHoursAvailable, 1));
+        replyNext.Text.Should().Be(new TotalHoursAvailableSuccess(totalHours: 1).Message);
         replyNext.Type.Should().Be(ActivityTypes.Message);
 
         replyNext     = _testClient.GetNextReply<IMessageActivity>();
@@ -94,10 +94,10 @@ public partial class RootDialogTests
         reply.Type.Should().Be(ActivityTypes.Typing);
 
         var replyNext     = _testClient.GetNextReply<IMessageActivity>();
-        var rangeToPayMsg = string.Format(Messages.RangeToPayMinMax, PriceMin, PriceMax);
+        var rangeToPayMsg = new PaymentSuccess(PriceMin, PriceMax).Message;
         replyNext.Text
                  .Should()
-                 .Be(string.Format(Messages.SuccessfullyScheduledAppointment, rangeToPayMsg));
+                 .Be(new SuccessfullyScheduledAppointmentSuccess(rangeToPayMsg).Message);
         replyNext.Type.Should().Be(ActivityTypes.Message);
 
         replyNext         = _testClient.GetNextReply<IMessageActivity>();

--- a/tests/ChatBot/Dialogs/RootDialogTests.cs
+++ b/tests/ChatBot/Dialogs/RootDialogTests.cs
@@ -97,7 +97,7 @@ public partial class RootDialogTests
         var rangeToPayMsg = new PaymentSuccess(PriceMin, PriceMax).Message;
         replyNext.Text
                  .Should()
-                 .Be(new SuccessfullyScheduledAppointmentSuccess(rangeToPayMsg).Message);
+                 .Be(new ScheduledAppointmentSuccess(rangeToPayMsg).Message);
         replyNext.Type.Should().Be(ActivityTypes.Message);
 
         replyNext         = _testClient.GetNextReply<IMessageActivity>();

--- a/tests/ChatBot/GlobalUsings.cs
+++ b/tests/ChatBot/GlobalUsings.cs
@@ -21,3 +21,4 @@ global using DentallApp.Shared.Models;
 global using DentallApp.Shared.Configuration;
 global using DentallApp.Shared.Services;
 global using DentallApp.Shared.Resources.ApiResponses;
+global using DentallApp.Shared.Reasons;

--- a/tests/UnitTests/Features/Appointments/CancelAppointmentsUseCaseTests.cs
+++ b/tests/UnitTests/Features/Appointments/CancelAppointmentsUseCaseTests.cs
@@ -50,6 +50,9 @@ public class CancelAppointmentsUseCaseTests
     public async Task ExecuteAsync_WhenSomeAppointmentsCannotBeCancelled_ShouldReturnsResultWithAppointmentsId()
     {
         // Arrange
+        int[] expectedAppointmentsId = { 4, 5 };
+        int pastAppointments = 2;
+        var expectedMessage = new AppointmentThatHasAlreadyPassedEmployeeError(pastAppointments).Message;
         var request = new CancelAppointmentsRequest
         {
             Appointments = new List<CancelAppointmentsRequest.Appointment>
@@ -77,18 +80,21 @@ public class CancelAppointmentsUseCaseTests
         result.IsSuccess.Should().BeFalse();
         result.Message
             .Should()
-            .Be(string.Format(Messages.AppointmentThatHasAlreadyPassedEmployee, 2));
+            .Be(expectedMessage);
 
         result.Data
             .AppointmentsId
             .Should()
-            .BeEquivalentTo(new[] { 4, 5 });
+            .BeEquivalentTo(expectedAppointmentsId);
     }
 
     [Test]
     public async Task ExecuteAsync_WhenAppointmentsCannotBeCancelled_ShouldReturnsResultWithAppointmentsId()
     {
         // Arrange
+        int[] expectedAppointmentsId = { 1, 2, 3, 4, 5 };
+        int pastAppointments = 5;
+        var expectedMessage = new AppointmentThatHasAlreadyPassedEmployeeError(pastAppointments).Message;
         var request = new CancelAppointmentsRequest
         {
             Appointments = new List<CancelAppointmentsRequest.Appointment>
@@ -116,11 +122,11 @@ public class CancelAppointmentsUseCaseTests
         result.IsSuccess.Should().BeFalse();
         result.Message
             .Should()
-            .Be(string.Format(Messages.AppointmentThatHasAlreadyPassedEmployee, 5));
+            .Be(expectedMessage);
 
         result.Data
             .AppointmentsId
             .Should()
-            .BeEquivalentTo(new[] { 1, 2, 3, 4, 5 });
+            .BeEquivalentTo(expectedAppointmentsId);
     }
 }

--- a/tests/UnitTests/Features/Appointments/GetAvailableHours/GetAvailableHoursUseCaseTests.cs
+++ b/tests/UnitTests/Features/Appointments/GetAvailableHours/GetAvailableHoursUseCaseTests.cs
@@ -35,9 +35,8 @@ public class GetAvailableHoursUseCaseTests
     public async Task ExecuteAsync_WhenDentistIsNotAvailableOnGivenDay_ShouldReturnsAnErrorMessage()
     {
         // Arrange
-        var expectedMessage = string.Format(
-            Messages.DentistNotAvailable, 
-            WeekdayCollection.GetName(DayOfWeek.Sunday));
+        var weekDayName = WeekdayCollection.GetName(DayOfWeek.Sunday);
+        var expectedMessage = new DentistNotAvailableError(weekDayName).Message;
         var request = new AvailableTimeRangeRequest { AppointmentDate = new DateTime(2023, 01, 01) };
         Mock.Arrange(() => _queries.GetEmployeeScheduleAsync(Arg.AnyInt, Arg.AnyInt))
             .DoNothing();
@@ -55,9 +54,8 @@ public class GetAvailableHoursUseCaseTests
     public async Task ExecuteAsync_WhenEmployeeScheduleIsInactive_ShouldReturnsAnErrorMessage()
     {
         // Arrange
-        var expectedMessage = string.Format(
-            Messages.DentistNotAvailable, 
-            WeekdayCollection.GetName(DayOfWeek.Sunday));
+        var weekDayName = WeekdayCollection.GetName(DayOfWeek.Sunday);
+        var expectedMessage = new DentistNotAvailableError(weekDayName).Message;
         var request = new AvailableTimeRangeRequest { AppointmentDate = new DateTime(2023, 01, 01) };
         Mock.Arrange(() => _queries.GetEmployeeScheduleAsync(Arg.AnyInt, Arg.AnyInt))
             .ReturnsAsync(new EmployeeScheduleResponse { IsEmployeeScheculeDeleted = true });
@@ -75,9 +73,8 @@ public class GetAvailableHoursUseCaseTests
     public async Task ExecuteAsync_WhenOfficeScheduleIsInactive_ShouldReturnsAnErrorMessage()
     {
         // Arrange
-        var expectedMessage = string.Format(
-            Messages.OfficeClosedForSpecificDay, 
-            WeekdayCollection.GetName(DayOfWeek.Sunday));
+        var weekDayName = WeekdayCollection.GetName(DayOfWeek.Sunday);
+        var expectedMessage = new OfficeClosedForSpecificDayError(weekDayName).Message;
         var request = new AvailableTimeRangeRequest { AppointmentDate = new DateTime(2023, 01, 01) };
         Mock.Arrange(() => _queries.GetEmployeeScheduleAsync(Arg.AnyInt, Arg.AnyInt))
             .ReturnsAsync(new EmployeeScheduleResponse { IsOfficeScheduleDeleted = true });
@@ -95,9 +92,8 @@ public class GetAvailableHoursUseCaseTests
     public async Task ExecuteAsync_WhenOfficeIsInactive_ShouldReturnsAnErrorMessage()
     {
         // Arrange
-        var expectedMessage = string.Format(
-            Messages.OfficeClosedForSpecificDay, 
-            WeekdayCollection.GetName(DayOfWeek.Sunday));
+        var weekDayName = WeekdayCollection.GetName(DayOfWeek.Sunday);
+        var expectedMessage = new OfficeClosedForSpecificDayError(weekDayName).Message;
         var request = new AvailableTimeRangeRequest { AppointmentDate = new DateTime(2023, 01, 01) };
         Mock.Arrange(() => _queries.GetEmployeeScheduleAsync(Arg.AnyInt, Arg.AnyInt))
             .ReturnsAsync(new EmployeeScheduleResponse { IsOfficeDeleted = true });

--- a/tests/UnitTests/GlobalUsings.cs
+++ b/tests/UnitTests/GlobalUsings.cs
@@ -19,6 +19,7 @@ global using DentallApp.Shared.Domain;
 global using DentallApp.Shared.Appointments;
 global using DentallApp.Shared.Resources.Weekdays;
 global using DentallApp.Shared.Resources.ApiResponses;
+global using DentallApp.Shared.Reasons;
 global using DentallApp.Shared.Constants;
 global using DentallApp.Shared.Services;
 global using DentallApp.Shared.Configuration;


### PR DESCRIPTION
This change has only been applied for messages that have placeholders. In fact, formatted messages I don't use it that often.

The benefit of this approach is that the consumer does not need to know how the message is formatted, in my opinion, it makes the code look more expressive rather than using [string.Format](https://learn.microsoft.com/en-us/dotnet/api/system.string.format?view=net-8.0) directly.
The consumer does not even need to know what [string.Format](https://learn.microsoft.com/en-us/dotnet/api/system.string.format?view=net-8.0) means or how it works.