### PR TITLE
fix: Add TimeSpanJsonConverter type

### DIFF
--- a/src/HostApplication/GlobalUsings.cs
+++ b/src/HostApplication/GlobalUsings.cs
@@ -9,6 +9,7 @@ global using DentallApp.Infrastructure;
 global using DentallApp.Infrastructure.Services;
 global using DentallApp.Infrastructure.Persistence;
 
+global using DentallApp.Shared;
 global using DentallApp.Shared.Interfaces;
 global using DentallApp.Shared.Interfaces.Appointments;
 global using DentallApp.Shared.Interfaces.Persistence;

--- a/src/HostApplication/Program.cs
+++ b/src/HostApplication/Program.cs
@@ -30,6 +30,10 @@ builder.Services
         options.SuppressAsyncSuffixInActionNames = false;
         options.Filters.Add<TranslateResultToActionResultAttribute>();
     })
+    .AddJsonOptions(jsonOpts =>
+    {
+        jsonOpts.JsonSerializerOptions.Converters.Add(new TimeSpanJsonConverter());
+    })
     .AddCustomInvalidModelStateResponse()
     .AddApplicationParts();
 

--- a/src/Shared/GlobalUsings.cs
+++ b/src/Shared/GlobalUsings.cs
@@ -11,6 +11,7 @@ global using DentallApp.Shared.Models;
 global using DentallApp.Shared.Models.Claims;
 global using DentallApp.Shared.Interfaces;
 
+global using System.Text.Json;
 global using System.Text.Json.Serialization;
 global using System.Globalization;
 global using System.Data;

--- a/src/Shared/TimeSpanJsonConverter.cs
+++ b/src/Shared/TimeSpanJsonConverter.cs
@@ -1,0 +1,17 @@
+﻿namespace DentallApp.Shared;
+
+public class TimeSpanJsonConverter : JsonConverter<TimeSpan>
+{
+    public override TimeSpan Read(
+        ref Utf8JsonReader reader,
+        Type typeToConvert,
+        JsonSerializerOptions options) =>
+            TimeSpan.Parse(reader.GetString(), CultureInfo.InvariantCulture);
+
+    public override void Write(
+        Utf8JsonWriter writer,
+        TimeSpan timeSpan,
+        JsonSerializerOptions options) =>
+            writer.WriteStringValue(timeSpan.ToString(
+                @"hh\:mm", CultureInfo.InvariantCulture));
+}

--- a/tests/UnitTests/GlobalUsings.cs
+++ b/tests/UnitTests/GlobalUsings.cs
@@ -1,4 +1,6 @@
 global using System.Collections;
+global using System.Text.Json;
+global using System.Text.Json.Serialization;
 global using NUnit.Framework;
 global using FluentAssertions;
 global using Microsoft.Bot.Schema;
@@ -10,6 +12,7 @@ global using DentallApp.Features.Appointments.UseCases;
 global using DentallApp.Features.Appointments.UseCases.GetAvailableHours;
 global using DentallApp.Infrastructure.Services;
 
+global using DentallApp.Shared;
 global using DentallApp.Shared.Domain;
 global using DentallApp.Shared.Interfaces;
 global using DentallApp.Shared.Interfaces.Appointments;

--- a/tests/UnitTests/Shared/TimeSpanJsonConverterTests.cs
+++ b/tests/UnitTests/Shared/TimeSpanJsonConverterTests.cs
@@ -1,0 +1,66 @@
+﻿namespace UnitTests.Shared;
+
+public class TimeSpanJsonConverterTests
+{
+    class Person
+    {
+        [JsonConverter(typeof(TimeSpanJsonConverter))]
+        public TimeSpan StartHour { get; init; }
+    }
+
+    [TestCase("08:01",    8, 1, 0)]
+    [TestCase("8:1",      8, 1, 0)]
+    [TestCase("10:25",    10, 25, 0)]
+    [TestCase("08:01:25", 8, 1, 25)]
+    [TestCase("8:1:25",   8, 1, 25)]
+    public void Read_WhenDeserializingJson_ShouldConvertItToTimeSpanType(
+        string startHour,
+        int expectedHour,
+        int expectedMinute,
+        int expectedSecond)
+    {
+        // Arrange
+        var json =
+        $$"""
+        {
+            "StartHour": "{{startHour}}"
+        }
+        """;
+        var expectedTimeSpan = new TimeSpan(expectedHour, expectedMinute, expectedSecond);
+
+        // Act
+        Person person = JsonSerializer.Deserialize<Person>(json);
+        TimeSpan actual = person.StartHour;
+
+        // Assert
+        actual.Should().Be(expectedTimeSpan);
+    }
+
+    [TestCase(8, 1, 0, "08:01")]
+    [TestCase(8, 1, 10, "08:01")]
+    public void Write_WhenSerializingJson_ShouldConvertTimeSpanToHHmmFormat(
+        int hour, 
+        int minute,
+        int second,
+        string expectedStartHour)
+    {
+        // Arrange
+        var options = new JsonSerializerOptions { WriteIndented = true };
+        var person = new Person 
+        { 
+            StartHour = new TimeSpan(hour, minute, second) 
+        };
+        var expectedJson =
+        $$"""
+        {
+          "StartHour": "{{expectedStartHour}}"
+        }
+        """;
+
+        // Act
+        var jsonActual = JsonSerializer.Serialize(person, options);
+
+        // Assert
+        jsonActual.Should().Be(expectedJson);
+    }
+}


### PR DESCRIPTION
This PR fixes this error: *The JSON value could not be converted to System.TimeSpan.*
This error is occurring in the use case to cancel appointments by the dentist. For example, when the client sends in the "startHour" field a value like "07:38", this error is generated.
This error can also occur in other use cases where time slots are handled.

BREAKING CHANGE: This error did not occur in **.netcoreapp3.1**, when migrating to **.net 7** the error was generated.